### PR TITLE
change read_into to readinto for i2c call

### DIFF
--- a/adafruit_amg88xx.py
+++ b/adafruit_amg88xx.py
@@ -160,7 +160,7 @@ class Adafruit_AMG88xx:
 			for i in range(0, AMG88xx_PIXEL_ARRAY_SIZE):
 				buf[0] = AMG88xx_PIXEL_OFFSET + (i << 1)
 				i2c.write(buf, end=1, stop=False)
-				i2c.read_into(buf, start=1)
+				i2c.readinto(buf, start=1)
 				
 				raw = (buf[2] << 8) | buf[1]
 				converted = self.signedMag12ToFloat(raw) * AMG88xx_PIXEL_TEMP_CONVERSION


### PR DESCRIPTION
A forum post reported this error. I don't have this sensor to test the change, but the forum poster reported that it worked. https://forums.adafruit.com/viewtopic.php?f=8&t=127854