### PR TITLE
Correct pylint errors

### DIFF
--- a/examples/amg88xx_rpi_thermal_cam.py
+++ b/examples/amg88xx_rpi_thermal_cam.py
@@ -5,11 +5,11 @@ import os
 import math
 import time
 
+import numpy as np
+import pygame
 import busio
 import board
 
-import numpy as np
-import pygame
 from scipy.interpolate import griddata
 
 from colour import Color
@@ -28,7 +28,9 @@ MAXTEMP = 32.0
 COLORDEPTH = 1024
 
 os.putenv("SDL_FBDEV", "/dev/fb1")
+# pylint: disable=no-member
 pygame.init()
+# pylint: enable=no-member
 
 # initialize the sensor
 sensor = adafruit_amg88xx.AMG88XX(i2c_bus)

--- a/examples/amg88xx_rpi_thermal_cam_console.py
+++ b/examples/amg88xx_rpi_thermal_cam_console.py
@@ -4,9 +4,9 @@
 import sys
 import math
 import time
+import numpy as np
 import busio
 import board
-import numpy as np
 from scipy.interpolate import griddata
 from colour import Color
 import adafruit_amg88xx


### PR DESCRIPTION
 - order of imported modules
 - spurious missing pygame.init() due https://stackoverflow.com/questions/50569453/why-does-it-say-that-module-pygame-has-no-init-member